### PR TITLE
Basic JWT token logic

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,3 +7,6 @@ class Config(object):
         'sqlite:////' + os.path.join(basedir, 'app.db')
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    # DEV ONLY
+    JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY') or 'enter-the-shaolin'

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -19,3 +19,5 @@ api = Api(cmr)
 from clear_my_record_backend.server import routes, models, resources
 
 api.add_resource(resources.Register, '/register')
+api.add_resource(resources.Login, '/login')
+api.add_resource(resources.Me, '/me')

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -3,12 +3,19 @@ from clear_my_record_backend.config import Config
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_cors import CORS
+from flask_restful import Api
+from flask_jwt_extended import JWTManager
 
 cmr = Flask(__name__)
 cmr.config.from_object(Config)
 dbs = SQLAlchemy(cmr)
 migratate = Migrate(cmr, dbs)
 CORS(cmr)
+jwt = JWTManager(cmr)
+api = Api(cmr)
 
-# having this import here is key to avoid circular imports, sorry pep8
-from clear_my_record_backend.server import routes, models
+# having this import here is key to avoid circular imports as well as
+# being able to define  our API routes
+from clear_my_record_backend.server import routes, models, resources
+
+api.add_resource(resources.Register, '/register')

--- a/server/models.py
+++ b/server/models.py
@@ -1,5 +1,11 @@
 from datetime import datetime
 from clear_my_record_backend.server import dbs
+from werkzeug.security import generate_password_hash, check_password_hash
+
+
+def save_to_dbs(entity):
+    dbs.session.add(entity)
+    dbs.session.commit()
 
 
 class Qualifying_Question(dbs.Model):
@@ -46,4 +52,15 @@ class User(dbs.Model):
             setattr(self, key, kwargs[key])
 
     def __repr__(self):
-        return "<USER: {}".format(self.username)
+        return "<USER: {}>".format(self.username)
+
+    def set_password(self, password):
+        self.pw_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.pw_hash, password)
+
+    def exists(self):
+        name = User.query.filter_by(username=self.username).first()
+        email = User.query.filter_by(email=self.email).first()
+        return name is not None or email is not None

--- a/server/models.py
+++ b/server/models.py
@@ -64,3 +64,7 @@ class User(dbs.Model):
         name = User.query.filter_by(username=self.username).first()
         email = User.query.filter_by(email=self.email).first()
         return name is not None or email is not None
+
+    @classmethod
+    def find_by_email(cls, _email):
+        return cls.query.filter_by(email=_email).first()

--- a/server/models.py
+++ b/server/models.py
@@ -68,3 +68,7 @@ class User(dbs.Model):
     @classmethod
     def find_by_email(cls, _email):
         return cls.query.filter_by(email=_email).first()
+
+    @classmethod
+    def find_by_username(cls, _username):
+        return cls.query.filter_by(username=_username).first()

--- a/server/resources.py
+++ b/server/resources.py
@@ -65,8 +65,13 @@ class Login(Resource):
 
 
 class Me(Resource):
-    def get(self):
-        return {'message': 'what do you want'}
 
-    def post(self):
-        return {'message': 'yep it is you, the user'}
+    @jwt_required
+    def get(self):
+        curr_user = User.find_by_username(get_jwt_identity())
+        data = {'status': "success", 'data': {
+            'id': curr_user.id,
+            'username': curr_user.username
+        }}
+
+        return data

--- a/server/resources.py
+++ b/server/resources.py
@@ -1,9 +1,10 @@
-from flask import request, abort, Response
+from flask import request, abort, Response, jsonify
 from sqlalchemy.exc import SQLAlchemyError
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import (jwt_required, create_access_token,
-                                get_jwt_identity)
+                                create_refresh_token, get_jwt_identity)
 from clear_my_record_backend.server.models import User, save_to_dbs
+
 
 class Register(Resource):
     def post(self):
@@ -19,20 +20,31 @@ class Register(Resource):
         if new_user.exists():
             # TODO: some better exception handlers
             # This clumps both existing emails and usernames, separate erros.
-            abort(400)
+            msg = "Failure: User already exists."
+            return Response(msg, status=400, mimetype='text/plain')
+            # abort(400)
 
         try:
             save_to_dbs(new_user)
             msg = "Success. User {} created".format(new_user.username)
-            return Response(msg, status=200, mimetype='text/plain')
+            # return Response(msg, status=200, mimetype='text/plain')
         except SQLAlchemyError as e:
-
             msg = "Error while updating database: {}".format(e)
             return Response(msg, status=500)
         except Exception as e:
             # TODO: Try to get something more specific here for debuggin, etc.
             msg = "Unanticipated Error: {}".format(e)
             return Response(msg, status=500)
+
+        token = create_access_token(identity=new_user.username)
+        refresh = create_refresh_token(identity=new_user.username)
+        data = {'status': "success", 'data': {
+            'type': "bearer",
+            'token': token,
+            'refreshToken': refresh}}
+        # causes error lol
+        return data
+
 
 class Login(Resource):
     def post(self):

--- a/server/resources.py
+++ b/server/resources.py
@@ -1,11 +1,22 @@
+from flask import request
 from flask_restful import Resource
 
 
 class Register(Resource):
     def post(self):
-        return {'message': 'Register'}
+        return {'message': {'username': request.json['username'],
+                            'email': request.json['email'],
+                            'password': request.json['password']}}
 
 
-class UserLogin(Resource):
+class Login(Resource):
     def post(self):
         return {'message': 'User Login'}
+
+
+class Me(Resource):
+    def get(self):
+        return {'message': 'what do you want'}
+
+    def post(self):
+        return {'message': 'yep it is you, the user'}

--- a/server/resources.py
+++ b/server/resources.py
@@ -3,7 +3,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from flask_restful import Resource, reqparse
 from flask_jwt_extended import (jwt_required, create_access_token,
                                 create_refresh_token, get_jwt_identity)
-from clear_my_record_backend.server.models import User, save_to_dbs
+from clear_my_record_backend.server.models import User, save_to_dbs, dbs
 
 
 class Register(Resource):
@@ -48,7 +48,20 @@ class Register(Resource):
 
 class Login(Resource):
     def post(self):
-        return {'message': 'User Login'}
+        u = User.find_by_email(request.json['email'])
+        if u:
+            if u.check_password(request.json['password']):
+                token = create_access_token(identity=u.username)
+                refresh = create_refresh_token(identity=u.username)
+                data = {'status': "success", 'data': {
+                    'type': "bearer",
+                    'token': token,
+                    'refreshToken': refresh}}
+                return data
+            # TODO better error!
+            return "made it inside at least"
+        # TODO better error!
+        return "nope"
 
 
 class Me(Resource):

--- a/server/resources.py
+++ b/server/resources.py
@@ -1,0 +1,11 @@
+from flask_restful import Resource
+
+
+class Register(Resource):
+    def post(self):
+        return {'message': 'Register'}
+
+
+class UserLogin(Resource):
+    def post(self):
+        return {'message': 'User Login'}

--- a/server/resources.py
+++ b/server/resources.py
@@ -1,13 +1,38 @@
-from flask import request
-from flask_restful import Resource
-
+from flask import request, abort, Response
+from sqlalchemy.exc import SQLAlchemyError
+from flask_restful import Resource, reqparse
+from flask_jwt_extended import (jwt_required, create_access_token,
+                                get_jwt_identity)
+from clear_my_record_backend.server.models import User, save_to_dbs
 
 class Register(Resource):
     def post(self):
-        return {'message': {'username': request.json['username'],
-                            'email': request.json['email'],
-                            'password': request.json['password']}}
+        if not request.json:
+            abort(400)
 
+        new_user = User(
+            username=request.json['username'],
+            email=request.json['email'],
+        )
+        new_user.set_password(request.json['password'])
+
+        if new_user.exists():
+            # TODO: some better exception handlers
+            # This clumps both existing emails and usernames, separate erros.
+            abort(400)
+
+        try:
+            save_to_dbs(new_user)
+            msg = "Success. User {} created".format(new_user.username)
+            return Response(msg, status=200, mimetype='text/plain')
+        except SQLAlchemyError as e:
+
+            msg = "Error while updating database: {}".format(e)
+            return Response(msg, status=500)
+        except Exception as e:
+            # TODO: Try to get something more specific here for debuggin, etc.
+            msg = "Unanticipated Error: {}".format(e)
+            return Response(msg, status=500)
 
 class Login(Resource):
     def post(self):

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,7 +1,9 @@
 from flask import request, Response, abort
 from clear_my_record_backend.server import cmr, models, dbs
+from flask_jwt_extended import (jwt_required, create_access_token,
+                                get_jwt_identity)
+from flask_restful import Resource
 from datetime import datetime
-import time
 
 
 @cmr.route('/')


### PR DESCRIPTION
This PR implements the basic usage of JWT tokens with respect to the back end as well as allow for user registration.

As of this PR, we now have the following endpoints that properly discriminate and handle requests based on whether a user exists and their JWT token. These routes are:
- `/me`
- `/login`
- `/register`

We do nothing to store or manipulate the JWT tokens as of now.